### PR TITLE
fix(release): allow ORG_VSCE_PAT fallback

### DIFF
--- a/.github/workflows/reusable-release.yml
+++ b/.github/workflows/reusable-release.yml
@@ -47,6 +47,9 @@ on:
       VSCE_PAT:
         description: "VS Code Marketplace personal access token (vscode projects only)"
         required: false
+      ORG_VSCE_PAT:
+        description: "Organization-level fallback VS Code Marketplace PAT (vscode projects only)"
+        required: false
       NPM_TOKEN:
         description: "npm token for publishing (npm projects only)"
         required: false
@@ -178,12 +181,17 @@ jobs:
             exit 1
           fi
 
-          if [ -n "${{ secrets.VSCE_PAT }}" ]; then
+          PAT="${{ secrets.VSCE_PAT }}"
+          if [ -z "$PAT" ]; then
+            PAT="${{ secrets.ORG_VSCE_PAT }}"
+          fi
+
+          if [ -n "$PAT" ]; then
             echo "🏪 Publishing tested VSIX to VS Code Marketplace..."
-            vsce publish --packagePath "$VSIX_PATH" -p "${{ secrets.VSCE_PAT }}"
+            vsce publish --packagePath "$VSIX_PATH" -p "$PAT"
             echo "✅ Published to marketplace successfully!"
           else
-            echo "⚠️ VSCE_PAT secret not found - skipping marketplace publish"
+            echo "⚠️ VSCE_PAT/ORG_VSCE_PAT secret not found - skipping marketplace publish"
           fi
 
       # ─────────────────────────────────────

--- a/.github/workflows/reusable-setup-repo.yml
+++ b/.github/workflows/reusable-setup-repo.yml
@@ -370,7 +370,7 @@ jobs:
           echo "║  Next steps:                                           ║"
           echo "║  • Update resources/icon.png with your extension icon  ║"
           echo "║  • Configure activationEvents in package.json          ║"
-          echo "║  • Add VSCE_PAT secret (or use org-level token)        ║"
+          echo "║  • Add VSCE_PAT secret (or ORG_VSCE_PAT org secret)    ║"
           echo "║  • Start developing on a feature/* branch              ║"
           else
           echo "║  Next steps:                                           ║"


### PR DESCRIPTION
﻿References: winccoa-tools-pack/.github#43

Problem
- Some repos rely on an org secret named ORG_VSCE_PAT, but the reusable release workflow only accepted VSCE_PAT.

Fix
- Add optional secret ORG_VSCE_PAT to reusable-release.yml.
- Publish step now uses VSCE_PAT first, then falls back to ORG_VSCE_PAT.

Impact
- Release runs can publish without per-repo VSCE_PAT, as long as ORG_VSCE_PAT is available to the repo.
