### PR TITLE
feat(chore): Add workflow to auto-rebase open PRs

### DIFF
--- a/.github/workflows/rebase-open-prs.yml
+++ b/.github/workflows/rebase-open-prs.yml
@@ -1,0 +1,12 @@
+name: Rebase open PRs
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  rebase-prs:
+    uses: mPokornyETM/rebase-open-prs-action/.github/workflows/rebase-open-prs.yml@v1
+    secrets:
+      GH_PAT: ${{ secrets.GH_TOKEN_PAT }}


### PR DESCRIPTION
# Add auto-rebase open PRs workflow

This PR adds a GitHub Actions workflow that automatically rebases all open PRs
when the default branch (main) receives new commits.

## What it does

- Triggers on push to \$DefaultBranch\ branch
- Uses the reusable action \mPokornyETM/rebase-open-prs-action@v1\
- Requires \GH_TOKEN_PAT\ secret with \epo\ scope

## Requirements

Ensure the \GH_TOKEN_PAT\ organization secret is configured with a PAT that
has \epo\ scope for this organization.