### PR TITLE
docs: fix spelling errors and grammar in README and profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 **Professional project management and development tools for Siemens WinCC Open Architecture**
 
 This organization collects modular Node.js libraries, GitHub Actions, reusable workflows, and VS Code extensions for **Siemens WinCC Open Architecture** (SCADA) development.
-It provides essential tools for project management, code quality, testing, deploy and documentation for locale developments (vs-code extensions, AI MPC-server) and various CI/CD tools like github, gitlab, Jenkins, azure ...
+It provides essential tools for project management, code quality, testing, deployment, and documentation for local developments (vs-code extensions, AI MCP-server) and various CI/CD tools like github, gitlab, Jenkins, azure ...
 
 # 🧰 WinCC OA Tools Pack — Community & Governance
 
@@ -57,7 +57,7 @@ These documents explain how ideas move through the ecosystem and how we keep eve
 
 All new issues must use one of the templates provided in:
 
-.gith8b/ISSUE_TEMPLATE/
+.github/ISSUE_TEMPLATE/
 
 Available templates include:
 

--- a/profile/README.md
+++ b/profile/README.md
@@ -4,9 +4,9 @@
 **Professional project management and development tools for Siemens WinCC Open Architecture**
 
 This organization collects modular Node.js libraries, GitHub Actions, reusable workflows, and VS Code extensions for **Siemens WinCC Open Architecture** (SCADA) development.
-It provides essential tools for project management, code quality, testing, deploy and documentation for locale developments (vs-code extensions, AI MPC-server) and various CI/CD tools like github, gitlab, Jenkins, azure ...
+It provides essential tools for project management, code quality, testing, deploy and documentation for local developments (vs-code extensions, AI MCP-server) and various CI/CD tools like github, gitlab, Jenkins, azure ...
 
-### Highlights?
+### Highlights
 
 ✅ **Modern Development Experience** - Bring WinCC OA development into the modern IDE era  
 ✅ **Increased Productivity** - Automate repetitive tasks and streamline workflows  
@@ -30,9 +30,9 @@ Special thanks to all our [contributors](https://github.com/orgs/winccoa-tools-p
 
 ## 📜 License
 
-This project is basically licensed under the **MIT License** - see the [LICENSE](https://github.com/winccoa-tools-pack/.github/blob/main/LICENSE) file for details.
+This project is licensed under the **MIT License** - see the [LICENSE](https://github.com/winccoa-tools-pack/.github/blob/main/LICENSE) file for details.
 
-It might happens, that the partial repositories contains third party SW which are using other license models.
+Some repositories may contain third-party software that uses different license models.
 
 ---
 


### PR DESCRIPTION
## Summary
- Fixed spelling: "locale" → "local", "MPC" → "MCP", ".gith8b" → ".github"
- Fixed grammar: "testing, deploy" → "testing, deployment"
- Fixed vague license wording: "basically licensed" → "licensed"
- Fixed license grammar in third-party clause

Resolves part of winccoa-tools-pack/.github#73
