### PR TITLE
fix: reusable dependabot workflows without checkout

### DIFF
--- a/.github/workflows/reusable-dependabot-auto-merge.yml
+++ b/.github/workflows/reusable-dependabot-auto-merge.yml
@@ -66,15 +66,17 @@ jobs:
         shell: bash
         env:
           PR_URL: ${{ inputs.pr_url }}
+          GH_REPO: ${{ github.repository }}
           GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
-          gh pr update-branch --rebase "$PR_URL" || true
+          gh pr update-branch --repo "$GH_REPO" --rebase "$PR_URL" || true
 
       - name: Enable auto-merge
         shell: bash
         env:
           PR_URL: ${{ inputs.pr_url }}
+          GH_REPO: ${{ github.repository }}
           GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
@@ -83,4 +85,4 @@ jobs:
             squash|merge|rebase) ;;
             *) echo "Invalid merge_method: '$method' (expected squash|merge|rebase)" >&2; exit 2;;
           esac
-          gh pr merge --auto --"$method" "$PR_URL"
+          gh pr merge --repo "$GH_REPO" --auto --"$method" "$PR_URL"

--- a/.github/workflows/reusable-dependabot-refresh.yml
+++ b/.github/workflows/reusable-dependabot-refresh.yml
@@ -71,12 +71,14 @@ jobs:
         shell: bash
         env:
           GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
           BASE_BRANCH: ${{ inputs.base_branch }}
         run: |
           set -euo pipefail
 
           # Collect PR URLs (one per line) for open Dependabot PRs targeting BASE_BRANCH
           gh pr list \
+            --repo "$GH_REPO" \
             --state open \
             --base "$BASE_BRANCH" \
             --author "dependabot[bot]" \
@@ -99,11 +101,12 @@ jobs:
         shell: bash
         env:
           GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
         run: |
           set -euo pipefail
           while IFS= read -r pr; do
             echo "Updating branch: $pr"
-            gh pr update-branch --rebase "$pr" || true
+            gh pr update-branch --repo "$GH_REPO" --rebase "$pr" || true
           done < pr_urls.txt
 
       - name: Enable auto-merge
@@ -111,6 +114,7 @@ jobs:
         shell: bash
         env:
           GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
           MERGE_METHOD: ${{ inputs.merge_method }}
         run: |
           set -euo pipefail
@@ -123,5 +127,5 @@ jobs:
 
           while IFS= read -r pr; do
             echo "Enabling auto-merge ($method): $pr"
-            gh pr merge --auto --"$method" "$pr" || true
+            gh pr merge --repo "$GH_REPO" --auto --"$method" "$pr" || true
           done < pr_urls.txt


### PR DESCRIPTION
Fixes reusable dependabot workflows to not depend on a git checkout by always passing --repo (GH_REPO) to gh commands. Prevents failures like: 'fatal: not a git repository'.