### PR TITLE
ci: optional auto-approve for Dependabot PRs

### DIFF
--- a/.github/workflows/reusable-dependabot-auto-merge.yml
+++ b/.github/workflows/reusable-dependabot-auto-merge.yml
@@ -30,6 +30,11 @@ on:
         description: "Pull request URL (e.g. https://github.com/OWNER/REPO/pull/123)"
         required: true
         type: string
+      approve_pr:
+        description: "Whether to auto-approve the PR (required only if branch protection requires approvals)"
+        required: false
+        default: false
+        type: boolean
       merge_method:
         description: "Merge method (squash|merge|rebase)"
         required: false
@@ -71,6 +76,17 @@ jobs:
         run: |
           set -euo pipefail
           gh pr update-branch --repo "$GH_REPO" --rebase "$PR_URL" || true
+
+      - name: Approve PR (optional)
+        if: inputs.approve_pr
+        shell: bash
+        env:
+          PR_URL: ${{ inputs.pr_url }}
+          GH_REPO: ${{ github.repository }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          gh pr review --repo "$GH_REPO" --approve "$PR_URL" --body "Auto-approved Dependabot PR." || true
 
       - name: Enable auto-merge
         shell: bash

--- a/.github/workflows/reusable-dependabot-refresh.yml
+++ b/.github/workflows/reusable-dependabot-refresh.yml
@@ -45,6 +45,11 @@ on:
         required: false
         default: true
         type: boolean
+      approve_prs:
+        description: "Whether to auto-approve Dependabot PRs (use only if branch protection requires approvals)"
+        required: false
+        default: false
+        type: boolean
       enable_auto_merge:
         description: "Whether to enable auto-merge on PRs (true recommended)"
         required: false
@@ -107,6 +112,19 @@ jobs:
           while IFS= read -r pr; do
             echo "Updating branch: $pr"
             gh pr update-branch --repo "$GH_REPO" --rebase "$pr" || true
+          done < pr_urls.txt
+
+      - name: Approve PRs (optional)
+        if: steps.list.outputs.count != '0' && inputs.approve_prs
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          while IFS= read -r pr; do
+            echo "Approving: $pr"
+            gh pr review --repo "$GH_REPO" --approve "$pr" --body "Auto-approved Dependabot PR." || true
           done < pr_urls.txt
 
       - name: Enable auto-merge


### PR DESCRIPTION
Adds opt-in inputs to the reusable Dependabot workflows to auto-approve Dependabot PRs via GitHub Actions (gh pr review --approve). Default remains OFF.