### PR TITLE
ci: use PAT for Dependabot branch updates

### DIFF
--- a/.github/workflows/reusable-dependabot-auto-merge.yml
+++ b/.github/workflows/reusable-dependabot-auto-merge.yml
@@ -45,6 +45,10 @@ on:
         required: false
         default: true
         type: boolean
+    secrets:
+      REPO_ADMIN_TOKEN:
+        description: "PAT with repo access (recommended). Ensures branch updates trigger downstream workflows; falls back to GITHUB_TOKEN if unset."
+        required: false
 
 permissions: {}
 
@@ -72,7 +76,7 @@ jobs:
         env:
           PR_URL: ${{ inputs.pr_url }}
           GH_REPO: ${{ github.repository }}
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.REPO_ADMIN_TOKEN != '' && secrets.REPO_ADMIN_TOKEN || github.token }}
         run: |
           set -euo pipefail
           gh pr update-branch --repo "$GH_REPO" --rebase "$PR_URL" || true
@@ -83,7 +87,7 @@ jobs:
         env:
           PR_URL: ${{ inputs.pr_url }}
           GH_REPO: ${{ github.repository }}
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.REPO_ADMIN_TOKEN != '' && secrets.REPO_ADMIN_TOKEN || github.token }}
         run: |
           set -euo pipefail
           gh pr review --repo "$GH_REPO" --approve "$PR_URL" --body "Auto-approved Dependabot PR." || true
@@ -93,7 +97,7 @@ jobs:
         env:
           PR_URL: ${{ inputs.pr_url }}
           GH_REPO: ${{ github.repository }}
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.REPO_ADMIN_TOKEN != '' && secrets.REPO_ADMIN_TOKEN || github.token }}
         run: |
           set -euo pipefail
           method="${{ inputs.merge_method }}"

--- a/.github/workflows/reusable-dependabot-refresh.yml
+++ b/.github/workflows/reusable-dependabot-refresh.yml
@@ -55,6 +55,10 @@ on:
         required: false
         default: true
         type: boolean
+    secrets:
+      REPO_ADMIN_TOKEN:
+        description: "PAT with repo access (recommended). Ensures branch updates trigger downstream workflows; falls back to GITHUB_TOKEN if unset."
+        required: false
 
 permissions: {}
 
@@ -75,7 +79,7 @@ jobs:
         id: list
         shell: bash
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.REPO_ADMIN_TOKEN != '' && secrets.REPO_ADMIN_TOKEN || github.token }}
           GH_REPO: ${{ github.repository }}
           BASE_BRANCH: ${{ inputs.base_branch }}
         run: |
@@ -105,7 +109,7 @@ jobs:
         if: steps.list.outputs.count != '0' && inputs.update_branch
         shell: bash
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.REPO_ADMIN_TOKEN != '' && secrets.REPO_ADMIN_TOKEN || github.token }}
           GH_REPO: ${{ github.repository }}
         run: |
           set -euo pipefail
@@ -118,7 +122,7 @@ jobs:
         if: steps.list.outputs.count != '0' && inputs.approve_prs
         shell: bash
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.REPO_ADMIN_TOKEN != '' && secrets.REPO_ADMIN_TOKEN || github.token }}
           GH_REPO: ${{ github.repository }}
         run: |
           set -euo pipefail
@@ -131,7 +135,7 @@ jobs:
         if: steps.list.outputs.count != '0' && inputs.enable_auto_merge
         shell: bash
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.REPO_ADMIN_TOKEN != '' && secrets.REPO_ADMIN_TOKEN || github.token }}
           GH_REPO: ${{ github.repository }}
           MERGE_METHOD: ${{ inputs.merge_method }}
         run: |


### PR DESCRIPTION
Use optional REPO_ADMIN_TOKEN (PAT) in reusable Dependabot workflows so branch update/approve/auto-merge operations trigger required downstream checks. Falls back to GITHUB_TOKEN if unset.