### PR TITLE
Fix reusable dependabot release workflow YAML parsing

### DIFF
--- a/.github/workflows/reusable-dependabot-release-pr.yml
+++ b/.github/workflows/reusable-dependabot-release-pr.yml
@@ -228,13 +228,7 @@ jobs:
           set -euo pipefail
 
           title="chore(release): v$NEXT"
-          body=$(
-            printf '%s\n\n%s\n%s\n\n%s\n' \
-              'This PR was created automatically after a Dependabot PR was merged into `${{ inputs.base_branch }}`.' \
-              '- Version bump: `${{ inputs.version_file }}` -> `'$NEXT'` (patch +0.0.1)' \
-              '- Branch: `'$RELEASE_BRANCH'`' \
-              'Once this PR is merged, the normal prerelease/release pipelines should run.'
-          )
+          body=$(printf '%s\n\n%s\n%s\n\n%s\n' "This PR was created automatically after a Dependabot PR was merged into \`${{ inputs.base_branch }}\`." "- Version bump: \`${{ inputs.version_file }}\` -> \`$NEXT\` (patch +0.0.1)" "- Branch: \`$RELEASE_BRANCH\`" "Once this PR is merged, the normal prerelease/release pipelines should run.")
 
           pr_url=$(gh pr create \
             --repo "$GH_REPO" \


### PR DESCRIPTION
Fixes GitHub Actions error: error parsing called workflow (YAML syntax failure in called reusable workflow).

Simplifies the PR body construction to avoid quoting/backslash patterns that triggered the parser, without changing the intended PR text.
