### PR TITLE
feat(workflows): Dependabot release PR supports auto_release

### DIFF
--- a/.github/workflows/reusable-create-release-branch.yml
+++ b/.github/workflows/reusable-create-release-branch.yml
@@ -89,6 +89,11 @@ on:
         required: false
         default: "chore,release"
         type: string
+      auto_release:
+        description: "If true: automatically add the 3-day no-review countdown label (used for automated releases)"
+        required: false
+        default: false
+        type: boolean
       project_type:
         description: "Project type: 'vscode' for VS Code extensions, 'npm' for npm libraries"
         required: true
@@ -96,6 +101,14 @@ on:
     secrets:
       REPO_ADMIN_TOKEN:
         required: false
+
+    outputs:
+      branch:
+        description: "Created or reused release branch name"
+        value: ${{ jobs.create.outputs.branch }}
+      pr_url:
+        description: "Created or reused PR URL"
+        value: ${{ jobs.create.outputs.pr_url }}
 
 concurrency:
   group: create-release-branch-${{ github.repository }}-${{ inputs.version }}
@@ -109,6 +122,9 @@ permissions:
 jobs:
   create:
     runs-on: ubuntu-latest
+    outputs:
+      branch: ${{ steps.branch.outputs.branch }}
+      pr_url: ${{ steps.pr.outputs.pr_url }}
     steps:
       # ── 1. Create the release / hotfix branch via the GitHub API ────────
       - name: Create branch (release/hotfix)
@@ -286,6 +302,13 @@ jobs:
             const draft = ${{ inputs.draft }};
             const labelsRaw = '${{ inputs.labels }}'.trim();
             const labels = labelsRaw ? labelsRaw.split(',').map(l => l.trim()).filter(Boolean) : [];
+            const autoRelease = ${{ inputs.auto_release }};
+            if (autoRelease) {
+              labels.push('merge-in-3-days-without-review');
+            }
+
+            // Deduplicate labels
+            const uniqueLabels = Array.from(new Set(labels));
 
             const head = `${context.repo.owner}:${releaseBranch}`;
             const existing = await github.rest.pulls.list({
@@ -300,6 +323,21 @@ jobs:
             if (existing.data.length > 0) {
               const pr = existing.data[0];
               core.info(`PR already exists: ${pr.html_url}`);
+
+              if (uniqueLabels.length > 0) {
+                try {
+                  await github.rest.issues.addLabels({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    issue_number: pr.number,
+                    labels: uniqueLabels,
+                  });
+                  core.info(`Applied labels: ${uniqueLabels.join(', ')}`);
+                } catch (error) {
+                  core.warning(`Could not apply labels (${uniqueLabels.join(', ')}): ${error.message}`);
+                }
+              }
+
               core.setOutput('branch', releaseBranch);
               core.setOutput('pr_url', pr.html_url);
               return;
@@ -346,17 +384,17 @@ jobs:
 
             core.info(`Created PR: ${pr.data.html_url}`);
 
-            if (labels.length > 0) {
+            if (uniqueLabels.length > 0) {
               try {
                 await github.rest.issues.addLabels({
                   owner: context.repo.owner,
                   repo: context.repo.repo,
                   issue_number: pr.data.number,
-                  labels,
+                  labels: uniqueLabels,
                 });
-                core.info(`Applied labels: ${labels.join(', ')}`);
+                core.info(`Applied labels: ${uniqueLabels.join(', ')}`);
               } catch (error) {
-                core.warning(`Could not apply labels (${labels.join(', ')}): ${error.message}`);
+                core.warning(`Could not apply labels (${uniqueLabels.join(', ')}): ${error.message}`);
               }
             }
 

--- a/.github/workflows/reusable-dependabot-release-pr.yml
+++ b/.github/workflows/reusable-dependabot-release-pr.yml
@@ -64,6 +64,16 @@ on:
         required: false
         default: "squash"
         type: string
+      project_type:
+        description: "Project type: 'vscode' for VS Code extensions, 'npm' for npm libraries"
+        required: false
+        default: "npm"
+        type: string
+      auto_release:
+        description: "If true: add a 3-day no-review countdown label so the PR auto-approves/merges after the window"
+        required: false
+        default: false
+        type: boolean
     secrets:
       REPO_ADMIN_TOKEN:
         description: "PAT with repo access (recommended). Helps ensure PR creation triggers downstream workflows reliably."
@@ -76,12 +86,17 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  create-release-pr:
-    name: Create release PR (Dependabot)
+  detect:
+    name: Detect + compute next version
     runs-on: ubuntu-latest
     permissions:
       contents: write
       pull-requests: write
+    outputs:
+      dependabot: ${{ steps.detect.outputs.dependabot }}
+      next: ${{ steps.ver.outputs.next }}
+      found: ${{ steps.existing.outputs.found }}
+      existing_url: ${{ steps.existing.outputs.url }}
 
     steps:
       - name: Checkout base branch
@@ -189,61 +204,52 @@ jobs:
             echo "found=false" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Create or update release branch (version bump)
-        if: steps.detect.outputs.dependabot == 'true' && steps.existing.outputs.found != 'true'
-        shell: bash
-        env:
-          GH_TOKEN: ${{ secrets.REPO_ADMIN_TOKEN != '' && secrets.REPO_ADMIN_TOKEN || github.token }}
-          VERSION_FILE: ${{ inputs.version_file }}
-          VERSION_KEY: ${{ inputs.version_key }}
-          NEXT: ${{ steps.ver.outputs.next }}
-          RELEASE_BRANCH: ${{ steps.ver.outputs.release_branch }}
-          BASE_BRANCH: ${{ inputs.base_branch }}
-        run: |
-          set -euo pipefail
 
-          git fetch origin --prune
+  create-release-pr:
+    name: Create release branch + PR (central reusable)
+    needs: [detect]
+    if: needs.detect.outputs.dependabot == 'true' && needs.detect.outputs.found != 'true'
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+    uses: winccoa-tools-pack/.github/.github/workflows/reusable-create-release-branch.yml@main
+    secrets: inherit
+    with:
+      kind: release
+      version: ${{ needs.detect.outputs.next }}
+      base_branch: ${{ inputs.base_branch }}
+      target_branch: ${{ inputs.target_branch }}
+      draft: false
+      labels: "chore,release"
+      project_type: ${{ inputs.project_type }}
+      auto_release: ${{ inputs.auto_release }}
 
-          # Create branch from current base branch state
-          git checkout -B "$RELEASE_BRANCH" "origin/$BASE_BRANCH"
-
-          # Update version in JSON file
-          node -e "const fs=require('fs'); const f=process.env.VERSION_FILE; const k=process.env.VERSION_KEY; const next=process.env.NEXT; const obj=JSON.parse(fs.readFileSync(f,'utf8')); obj[k]=next; fs.writeFileSync(f, JSON.stringify(obj,null,2)+'\n');"
-
-          git add "$VERSION_FILE"
-          git commit -m "chore(release): v$NEXT"
-
-          git push -u origin "$RELEASE_BRANCH"
-
-      - name: Open release PR
-        if: steps.detect.outputs.dependabot == 'true' && steps.existing.outputs.found != 'true'
+  enable-auto-merge:
+    name: Enable auto-merge (optional)
+    needs: [detect, create-release-pr]
+    if: inputs.enable_auto_merge && needs.detect.outputs.dependabot == 'true' && needs.detect.outputs.found != 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Enable auto-merge on PR
         shell: bash
         env:
           GH_TOKEN: ${{ secrets.REPO_ADMIN_TOKEN != '' && secrets.REPO_ADMIN_TOKEN || github.token }}
           GH_REPO: ${{ github.repository }}
-          TARGET_BRANCH: ${{ inputs.target_branch }}
-          RELEASE_BRANCH: ${{ steps.ver.outputs.release_branch }}
-          NEXT: ${{ steps.ver.outputs.next }}
+          PR_URL: ${{ needs.create-release-pr.outputs.pr_url }}
         run: |
           set -euo pipefail
-
-          title="chore(release): v$NEXT"
-          body=$(printf '%s\n\n%s\n%s\n\n%s\n' "This PR was created automatically after a Dependabot PR was merged into \`${{ inputs.base_branch }}\`." "- Version bump: \`${{ inputs.version_file }}\` -> \`$NEXT\` (patch +0.0.1)" "- Branch: \`$RELEASE_BRANCH\`" "Once this PR is merged, the normal prerelease/release pipelines should run.")
-
-          pr_url=$(gh pr create \
-            --repo "$GH_REPO" \
-            --base "$TARGET_BRANCH" \
-            --head "$RELEASE_BRANCH" \
-            --title "$title" \
-            --body "$body")
-
-          echo "Created release PR: $pr_url"
-
-          if [ "${{ inputs.enable_auto_merge }}" = "true" ]; then
-            method="${{ inputs.auto_merge_method }}"
-            case "$method" in
-              squash|merge|rebase) ;;
-              *) echo "Invalid auto_merge_method: '$method'" >&2; exit 2;;
-            esac
-            gh pr merge --repo "$GH_REPO" --auto --"$method" "$pr_url" || true
+          if [ -z "${PR_URL}" ]; then
+            echo "No PR URL available; cannot enable auto-merge." >&2
+            exit 0
           fi
+
+          method="${{ inputs.auto_merge_method }}"
+          case "$method" in
+            squash|merge|rebase) ;;
+            *) echo "Invalid auto_merge_method: '$method'" >&2; exit 2;;
+          esac
+
+          gh pr merge --repo "$GH_REPO" --auto --"$method" "$PR_URL" || true


### PR DESCRIPTION
Adds support for npm-winccoa-core showcase changes:

- Extend reusable-dependabot-release-pr.yml with inputs: project_type, auto_release
- Delegate branch/PR creation to reusable-create-release-branch.yml
- Add outputs + auto_release label support to reusable-create-release-branch.yml

This fixes startup failures in downstream callers that already pass project_type/auto_release.
