### PR TITLE
fix(workflows): dependabot update-branch uses GITHUB_TOKEN

### DIFF
--- a/.github/workflows/reusable-dependabot-auto-merge.yml
+++ b/.github/workflows/reusable-dependabot-auto-merge.yml
@@ -76,7 +76,9 @@ jobs:
         env:
           PR_URL: ${{ inputs.pr_url }}
           GH_REPO: ${{ github.repository }}
-          GH_TOKEN: ${{ secrets.REPO_ADMIN_TOKEN != '' && secrets.REPO_ADMIN_TOKEN || github.token }}
+          # Use GITHUB_TOKEN for updating branches to avoid PAT `workflow` scope restrictions
+          # when PRs modify workflow files.
+          GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
           gh pr update-branch --repo "$GH_REPO" --rebase "$PR_URL" || true

--- a/.github/workflows/reusable-dependabot-refresh.yml
+++ b/.github/workflows/reusable-dependabot-refresh.yml
@@ -109,7 +109,9 @@ jobs:
         if: steps.list.outputs.count != '0' && inputs.update_branch
         shell: bash
         env:
-          GH_TOKEN: ${{ secrets.REPO_ADMIN_TOKEN != '' && secrets.REPO_ADMIN_TOKEN || github.token }}
+          # Use GITHUB_TOKEN for updating branches to avoid PAT `workflow` scope restrictions
+          # when PRs modify workflow files.
+          GH_TOKEN: ${{ github.token }}
           GH_REPO: ${{ github.repository }}
         run: |
           set -euo pipefail


### PR DESCRIPTION
Fixes Dependabot PRs getting stuck "Behind" when they touch workflow files.

Root cause:
- gh pr update-branch uses a PAT (REPO_ADMIN_TOKEN) when present
- GitHub blocks PATs without `workflow` scope from updating branches that modify `.github/workflows/*`

Change:
- Use `github.token` for update-branch steps (auto-merge/refresh)
- Keep PAT fallback for approve/merge operations
