### PR TITLE
fix(workflows): dependabot update-branch prefers REPO_ADMIN_TOKEN

### DIFF
--- a/.github/workflows/reusable-dependabot-auto-merge.yml
+++ b/.github/workflows/reusable-dependabot-auto-merge.yml
@@ -76,9 +76,10 @@ jobs:
         env:
           PR_URL: ${{ inputs.pr_url }}
           GH_REPO: ${{ github.repository }}
-          # Use GITHUB_TOKEN for updating branches to avoid PAT `workflow` scope restrictions
-          # when PRs modify workflow files.
-          GH_TOKEN: ${{ github.token }}
+          # NOTE: Updating PR branches can be blocked when the PR modifies workflow files.
+          # If you want this to work for workflow-touching PRs, provide REPO_ADMIN_TOKEN
+          # with sufficient workflow permissions.
+          GH_TOKEN: ${{ secrets.REPO_ADMIN_TOKEN != '' && secrets.REPO_ADMIN_TOKEN || github.token }}
         run: |
           set -euo pipefail
           gh pr update-branch --repo "$GH_REPO" --rebase "$PR_URL" || true

--- a/.github/workflows/reusable-dependabot-refresh.yml
+++ b/.github/workflows/reusable-dependabot-refresh.yml
@@ -109,9 +109,10 @@ jobs:
         if: steps.list.outputs.count != '0' && inputs.update_branch
         shell: bash
         env:
-          # Use GITHUB_TOKEN for updating branches to avoid PAT `workflow` scope restrictions
-          # when PRs modify workflow files.
-          GH_TOKEN: ${{ github.token }}
+          # NOTE: Updating PR branches can be blocked when the PR modifies workflow files.
+          # If you want this to work for workflow-touching PRs, provide REPO_ADMIN_TOKEN
+          # with sufficient workflow permissions.
+          GH_TOKEN: ${{ secrets.REPO_ADMIN_TOKEN != '' && secrets.REPO_ADMIN_TOKEN || github.token }}
           GH_REPO: ${{ github.repository }}
         run: |
           set -euo pipefail


### PR DESCRIPTION
Follow-up to #94.

Problem:
- For PRs that modify `.github/workflows/*`, GitHub blocks `gh pr update-branch` unless the token has workflow permissions.
- `github.token` is a GitHub App token and currently fails with:
  "refusing to allow a GitHub App to create or update workflow ... without workflows permission"

Fix:
- Prefer `secrets.REPO_ADMIN_TOKEN` for `update-branch` when provided.
- This allows using a classic PAT with `workflow` scope (or equivalent) so Dependabot PRs can be kept up-to-date automatically.
