### PR TITLE
feat(workflows): dedupe dependabot approval + label auto-merge

### DIFF
--- a/.github/workflows/reusable-dependabot-auto-merge.yml
+++ b/.github/workflows/reusable-dependabot-auto-merge.yml
@@ -59,6 +59,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+      issues: write
 
     steps:
       - name: Validate actor (defense in depth)
@@ -93,6 +94,22 @@ jobs:
           GH_TOKEN: ${{ secrets.REPO_ADMIN_TOKEN != '' && secrets.REPO_ADMIN_TOKEN || github.token }}
         run: |
           set -euo pipefail
+
+          pr_number=$(echo "$PR_URL" | sed -n 's#.*/pull/\([0-9]\+\).*#\1#p')
+          if [ -z "$pr_number" ]; then
+            echo "Could not parse PR number from URL: $PR_URL" >&2
+            exit 1
+          fi
+
+          me=$(gh api user --jq .login)
+          echo "Approver identity: $me"
+
+          already=$(gh api "/repos/$GH_REPO/pulls/$pr_number/reviews" --jq "[.[] | select(.user.login == \"$me\" and .state == \"APPROVED\")] | length")
+          if [ "$already" -gt 0 ]; then
+            echo "Already approved by $me; skipping duplicate approval comment."
+            exit 0
+          fi
+
           gh pr review --repo "$GH_REPO" --approve "$PR_URL" --body "Auto-approved Dependabot PR." || true
 
       - name: Enable auto-merge
@@ -109,3 +126,19 @@ jobs:
             *) echo "Invalid merge_method: '$method' (expected squash|merge|rebase)" >&2; exit 2;;
           esac
           gh pr merge --repo "$GH_REPO" --auto --"$method" "$PR_URL"
+
+      - name: Label PR (merge without review)
+        shell: bash
+        env:
+          PR_URL: ${{ inputs.pr_url }}
+          GH_REPO: ${{ github.repository }}
+          GH_TOKEN: ${{ secrets.REPO_ADMIN_TOKEN != '' && secrets.REPO_ADMIN_TOKEN || github.token }}
+        run: |
+          set -euo pipefail
+          label="merge-without-review"
+
+          # Create label if missing (best-effort)
+          gh api --silent "/repos/$GH_REPO/labels/$label" >/dev/null 2>&1 || \
+            gh api --silent -X POST "/repos/$GH_REPO/labels" -f name="$label" -f color="BFDADC" -f description="Configured to merge automatically without waiting for review." >/dev/null 2>&1 || true
+
+          gh pr edit --repo "$GH_REPO" "$PR_URL" --add-label "$label" || true

--- a/.github/workflows/reusable-dependabot-auto-merge.yml
+++ b/.github/workflows/reusable-dependabot-auto-merge.yml
@@ -76,9 +76,10 @@ jobs:
         env:
           PR_URL: ${{ inputs.pr_url }}
           GH_REPO: ${{ github.repository }}
-          # Use GITHUB_TOKEN for updating branches to avoid PAT `workflow` scope restrictions
-          # when PRs modify workflow files.
-          GH_TOKEN: ${{ github.token }}
+          # NOTE: Updating PR branches can be blocked when the PR modifies workflow files.
+          # If you want this to work for workflow-touching PRs, provide REPO_ADMIN_TOKEN
+          # with sufficient workflow permissions.
+          GH_TOKEN: ${{ secrets.REPO_ADMIN_TOKEN != '' && secrets.REPO_ADMIN_TOKEN || github.token }}
         run: |
           set -euo pipefail
           gh pr update-branch --repo "$GH_REPO" --rebase "$PR_URL" || true

--- a/.github/workflows/reusable-dependabot-refresh.yml
+++ b/.github/workflows/reusable-dependabot-refresh.yml
@@ -109,9 +109,10 @@ jobs:
         if: steps.list.outputs.count != '0' && inputs.update_branch
         shell: bash
         env:
-          # Use GITHUB_TOKEN for updating branches to avoid PAT `workflow` scope restrictions
-          # when PRs modify workflow files.
-          GH_TOKEN: ${{ github.token }}
+          # NOTE: Updating PR branches can be blocked when the PR modifies workflow files.
+          # If you want this to work for workflow-touching PRs, provide REPO_ADMIN_TOKEN
+          # with sufficient workflow permissions.
+          GH_TOKEN: ${{ secrets.REPO_ADMIN_TOKEN != '' && secrets.REPO_ADMIN_TOKEN || github.token }}
           GH_REPO: ${{ github.repository }}
         run: |
           set -euo pipefail

--- a/.github/workflows/reusable-dependabot-refresh.yml
+++ b/.github/workflows/reusable-dependabot-refresh.yml
@@ -73,6 +73,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+      issues: write
 
     steps:
       - name: List open Dependabot PRs
@@ -129,8 +130,22 @@ jobs:
           GH_REPO: ${{ github.repository }}
         run: |
           set -euo pipefail
+          me=$(gh api user --jq .login)
+          echo "Approver identity: $me"
           while IFS= read -r pr; do
             echo "Approving: $pr"
+            pr_number=$(echo "$pr" | sed -n 's#.*/pull/\([0-9]\+\).*#\1#p')
+            if [ -z "$pr_number" ]; then
+              echo "Could not parse PR number from URL: $pr" >&2
+              continue
+            fi
+
+            already=$(gh api "/repos/$GH_REPO/pulls/$pr_number/reviews" --jq "[.[] | select(.user.login == \"$me\" and .state == \"APPROVED\")] | length")
+            if [ "$already" -gt 0 ]; then
+              echo "Already approved by $me; skipping."
+              continue
+            fi
+
             gh pr review --repo "$GH_REPO" --approve "$pr" --body "Auto-approved Dependabot PR." || true
           done < pr_urls.txt
 
@@ -153,4 +168,22 @@ jobs:
           while IFS= read -r pr; do
             echo "Enabling auto-merge ($method): $pr"
             gh pr merge --repo "$GH_REPO" --auto --"$method" "$pr" || true
+          done < pr_urls.txt
+
+      - name: Label PRs (merge without review)
+        if: steps.list.outputs.count != '0' && inputs.enable_auto_merge
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.REPO_ADMIN_TOKEN != '' && secrets.REPO_ADMIN_TOKEN || github.token }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          label="merge-without-review"
+
+          # Create label if missing (best-effort)
+          gh api --silent "/repos/$GH_REPO/labels/$label" >/dev/null 2>&1 || \
+            gh api --silent -X POST "/repos/$GH_REPO/labels" -f name="$label" -f color="BFDADC" -f description="Configured to merge automatically without waiting for review." >/dev/null 2>&1 || true
+
+          while IFS= read -r pr; do
+            gh pr edit --repo "$GH_REPO" "$pr" --add-label "$label" || true
           done < pr_urls.txt


### PR DESCRIPTION
Changes:
- Post the "Auto-approved Dependabot PR." approval review only once per PR (skip if already approved by the same bot/user)
- Add label `merge-without-review` to PRs where auto-merge is enabled (best-effort; label created if missing)

Why:
- Avoid noisy repeated PR comments/reviews
- Make it obvious in the PR UI that it is configured to merge automatically
