### PR TITLE
fix(workflows): skip changelog generation when script missing

### DIFF
--- a/.github/workflows/reusable-create-release-branch.yml
+++ b/.github/workflows/reusable-create-release-branch.yml
@@ -262,7 +262,11 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          node scripts/generate-changelog.mjs --write
+          if [ -f "scripts/generate-changelog.mjs" ]; then
+            node scripts/generate-changelog.mjs --write
+          else
+            echo "No scripts/generate-changelog.mjs found; skipping CHANGELOG generation."
+          fi
 
       - name: Commit and push changes
         shell: bash


### PR DESCRIPTION
Fixes Create Release Branch + PR failing in repos that do not have scripts/generate-changelog.mjs.

Change:
- If scripts/generate-changelog.mjs exists: run it (current behavior)
- Else: skip with an informational message
