### PR TITLE
feat(workflows): reusable rebase-open-prs

### DIFF
--- a/.github/workflows/reusable-rebase-open-prs.yml
+++ b/.github/workflows/reusable-rebase-open-prs.yml
@@ -1,0 +1,18 @@
+name: "Reusable: Rebase open PRs"
+
+on:
+  workflow_call:
+    secrets:
+      GH_TOKEN_PAT:
+        description: "PAT used to rebase PR branches (needs repo + workflow permissions if rebasing PRs that touch workflows)"
+        required: true
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  rebase-prs:
+    uses: mPokornyETM/rebase-open-prs-action/.github/workflows/rebase-open-prs.yml@v1
+    secrets:
+      GH_PAT: ${{ secrets.GH_TOKEN_PAT }}


### PR DESCRIPTION
Adds an org-level reusable workflow wrapper for rebase-open-prs.

Why:
- Reuse a single, consistent implementation across repos
- Caller repos only need a thin trigger workflow and a GH_TOKEN_PAT secret

Notes:
- The PAT should include permissions to update branches; if rebasing PRs that touch workflows, it may need workflow permission.
